### PR TITLE
readme: update warning for archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Bluetooth Private Access
 
 > [!CAUTION]
-> Enrollment in the private access program is required to complete this
-> onboarding guide. Complete [this
-> form](https://hslp.golioth.io/bluetooth-cloud-early-access) to apply.
+> This repository is archived and Bluetooth support on Golioth is now availabe
+> to all users. Find out how to get started in the
+> [documentation](https://docs.golioth.io/connectivity/protocols/bluetooth).
 
 ![Gateway Device Page](./assets/gateway_device_page.png)
 


### PR DESCRIPTION
Updates the warning on the README.md to indicate that the repository is now archived and should not be used for interacting with Golioth's Bluetooth support.

This repository will be archived following merge of this PR.